### PR TITLE
Update email and app-specific password

### DIFF
--- a/lib/config/template/common.json
+++ b/lib/config/template/common.json
@@ -9,7 +9,7 @@
     "from":"Igarape <igarapetech@gmail.com>",
     "subject":"New Password",
     "service":"Gmail",
-    "user":"igarapetech@gmail.com",
-    "pass":"igarape73"
+    "user": "CopcastServer@gmail.com",
+    "pass": "hqhsaszvodjnobtm"
   }
 }

--- a/lib/config/template/development.json
+++ b/lib/config/template/development.json
@@ -22,7 +22,7 @@
     "administrator": "bruno@igarape.org.br",
     "from": "Igarape <igarapetech@gmail.com>",
     "service": "Gmail",
-    "user": "igarapetech@gmail.com",
-    "pass": "igarape73"
+    "user": "CopcastServer@gmail.com",
+    "pass": "hqhsaszvodjnobtm"
   }
 }


### PR DESCRIPTION
This updates the email address and uses an app-specific password to fix https://github.com/igarape/copcast-admin/issues/209

CopcastServer@gmail.com is a new email address I created, although we could use any email address.  To get an app-specific password, you need to first enable 2-factor authentication for the account (on accounts.google.com), then visit https://security.google.com/settings/security/apppasswords to create the password.

Going forward though I think it would be best not to have our PW stored on a publicly visible GitHub repo.  At that point we can create a new app password and revoke the old one.