### PR TITLE
Delete users and groups by setting isDeleted=true

### DIFF
--- a/lib/db/group.js
+++ b/lib/db/group.js
@@ -11,16 +11,21 @@ module.exports = function(sequelize, DataTypes) {
       unique : true
     },
     isAdmin : {
-        type : DataTypes.BOOLEAN
+      type : DataTypes.BOOLEAN
     },
     lat : {
-          type : DataTypes.FLOAT
+      type : DataTypes.FLOAT
     },
     lng : {
-          type : DataTypes.FLOAT
+      type : DataTypes.FLOAT
+    },
+    isDeleted : {
+      type : DataTypes.BOOLEAN,
+      defaultValue : false
     }
   }, {
-    tableName: 'groups',
+    // groups_active is a SQL view on groups selecting rows with isDeleted=false
+    tableName: 'groups_active',
     associate : function(models) {
       Group.hasMany(models.user);
     }

--- a/lib/db/user.js
+++ b/lib/db/user.js
@@ -67,10 +67,14 @@ module.exports = function(sequelize, DataTypes) {
       type : DataTypes.BOOLEAN,
       allowNull : false,
       defaultValue: true
+    },
+    isDeleted : {
+      type : DataTypes.BOOLEAN,
+      defaultValue : false
     }
-
   }, {
-    tableName: 'users',
+    // users_active is a SQL view on users selecting rows with isDeleted=false
+    tableName: 'users_active',
     timestamps: true,
     associate : function(models) {
       User.hasMany(models.accesstoken);

--- a/lib/groups/index.js
+++ b/lib/groups/index.js
@@ -12,8 +12,11 @@ app.delete('/groups/:id', auth.ensureAdminLevelOne, function(req, res) {
         if (group.id != groupCurrent.id ) {
           group.countUsers().then(function(countUsers){
             if (countUsers == 0) {
-              group.destroy();
-              res.sendStatus(200);
+              // Mark record deleted, rather than destroying it.
+              group.isDeleted = true;
+              group.save().then(function() {
+                res.sendStatus(200);
+              });
             } else {
               res.status(403).send("Has associated users");
             }
@@ -131,11 +134,11 @@ app.post('/groups', auth.ensureAdminLevelOne, function(req, res) {
 function getLocationsByGroup(groupId, initialDate, finalDate, accuracy, res) {
   db.sequelize.query(  'SELECT "location"."id", "location"."date", "location"."lat", "location"."lng", "user"."id" '+
   'AS "userId" FROM "locations" AS "location" '+
-  'LEFT OUTER JOIN "users" AS "user" '+
+  'LEFT OUTER JOIN "users_active" AS "user" '+
   'ON "location"."userId" = "user"."id" '+
   'WHERE "location"."id" IN (SELECT MAX("loc"."id") '+
   'FROM "locations" AS "loc" '+
-  'JOIN "users" AS "u" ON "u"."id" = "loc"."userId" '+
+  'JOIN "users_active" AS "u" ON "u"."id" = "loc"."userId" '+
   'WHERE (("u"."groupId" = ?) AND ("loc"."date" '+
   'BETWEEN ? AND ?) '+
   'AND ("loc"."accuracy" <= ? OR "loc"."accuracy" IS NULL )) '+

--- a/lib/incidents/index.js
+++ b/lib/incidents/index.js
@@ -117,7 +117,7 @@ app.get('/groups/:id/incidents/:initialDate/:finalDate', auth.ensureAdminLevelOn
 function getIncidentsByGroup(groupId, initialDate, finalDate, res) {
   db.sequelize.query(  'SELECT "incident"."id", "incident"."date", "incident"."lat", "incident"."lng", "user"."id" '+
     'AS "userId" FROM "incidents" AS "incident" '+
-    'LEFT OUTER JOIN "users" AS "user" '+
+    'LEFT OUTER JOIN "users_active" AS "user" '+
     'ON "incident"."userId" = "user"."id" '+
     'WHERE (("user"."groupId" = ?) AND ("incident"."date" '+
     'BETWEEN ? AND ?)) '+

--- a/lib/reports/index.js
+++ b/lib/reports/index.js
@@ -97,7 +97,7 @@ function loadIncidentForms(ret, group, fromDate, toDate, callback) {
 
   var replacements = {fromDate: fromDate, toDate: toDate};
   var query = 'SELECT gravity, COUNT(1) FROM "incidentForms" "form" ' +
-    'JOIN users "users" ON "form"."userId" = "users"."id" ' +
+    'JOIN users_active "users" ON "form"."userId" = "users"."id" ' +
     'WHERE "form"."accident" = true AND "form"."date" BETWEEN :fromDate AND :toDate ';
 
   if (!group.isAdmin) {
@@ -142,7 +142,7 @@ function getTotalAdminLogIn(dateRange, group, callback){
   console.log('getTotalRecordedMinutesByUser');
   var replacements = {fromDate: dateRange[0], toDate: dateRange[1], state: 'LOGGED_ADMIN'};
   var query = 'SELECT 1 FROM histories h '+
-    ' JOIN users u ON u.id = h."userId" '+
+    ' JOIN users_active u ON u.id = h."userId" '+
     ' WHERE "nextState" = :state AND date BETWEEN :fromDate AND :toDate ';
   if (!group.isAdmin){
     query = query + ' AND u."groupId" = :groupId ';
@@ -161,7 +161,7 @@ function getVideosPlayed(dateRange, group, callback){
   console.log('getVideosPlayed');
   var replacements = {fromDate: dateRange[0], toDate: dateRange[1], state: 'PLAYING_VIDEO'};
   var query = 'SELECT h.*, u.name FROM histories h '+
-    ' JOIN users u ON u.id = h."userId" '+
+    ' JOIN users_active u ON u.id = h."userId" '+
     ' WHERE "nextState" = :state AND date BETWEEN :fromDate AND :toDate ';
   if (!group.isAdmin){
     query = query + ' AND u."groupId" = :groupId ';
@@ -191,7 +191,7 @@ function getTotalOfState(fromDate, toDate, group, user, state, callback) {
     'JOIN histories "histNext" ON ' +
     '	"hist"."userId" = "histNext"."userId" ' +
     '	AND	"hist"."nextState" = "histNext"."previousState" ' +
-    'JOIN users "users" ON "users"."id" = "hist"."userId" ' +
+    'JOIN users_active "users" ON "users"."id" = "hist"."userId" ' +
     'WHERE "histNext"."id" IN (SELECT "histIn"."id" ' +
     '				FROM histories "histIn" ' +
     '				WHERE "histIn"."date" > "hist"."date" ' +
@@ -240,7 +240,7 @@ function getTotalRecordedMinutes(dateRange, where, callback) {
 function getTotalMissions(fromDate, toDate, user, callback) {
   console.log('getTotalMissions');
   db.sequelize.query('SELECT COUNT(1) FROM "histories" AS "histories" ' +
-    'INNER JOIN "users" AS "user" ON "histories"."userId" = "user"."id" WHERE ' +
+    'INNER JOIN "users_active" AS "user" ON "histories"."userId" = "user"."id" WHERE ' +
     '"histories"."date" BETWEEN :fromDate AND :toDate ' +
     'AND "user"."id" = :userId AND "previousState" = :state AND "nextState" <> :streamingState ' +
     'AND "nextState" <> :pausedState', {
@@ -256,7 +256,7 @@ function getTotalVideoInformationByUser(fromDate, toDate, userId, callback) {
   console.log('getTotalRecordedMinutesByUser');
   db.sequelize.query('SELECT SUM("duration") AS "sum", SUM("filesize") as "filesize", to_char("video"."date",\'YYYY-MM-DD\') AS "date"' +
     'FROM "videos" AS "video" ' +
-    'INNER JOIN "users" AS "user" ON "video"."userId" = "user"."id" WHERE ' +
+    'INNER JOIN "users_active" AS "user" ON "video"."userId" = "user"."id" WHERE ' +
     '"video"."date" BETWEEN :fromDate AND :toDate ' +
     'AND "user"."id" = :userId ' +
     'GROUP BY 3', {

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -172,7 +172,7 @@ app.get('/users', auth.ensureAdminLevelOne, function (req, res) {
   db.group.findById(req.user.groupId).then(function (group) {
     var where = [],
       params = [],
-      select = ['SELECT DISTINCT U.id, U.username, U.\"lastLocationUpdateDate\", U.name, U.\"profilePicture\", G.name as group, U.\"isEnabled\", U.\"createdAt\" FROM "users" U LEFT OUTER JOIN "groups" G ON U."groupId" = G.id'];
+      select = ['SELECT DISTINCT U.id, U.username, U.\"lastLocationUpdateDate\", U.name, U.\"profilePicture\", G.name as group, U.\"isEnabled\", U.\"createdAt\" FROM "users_active" U LEFT OUTER JOIN "groups_active" G ON U."groupId" = G.id'];
 
     if (req.query.user) {
       req.query.user = '%' + req.query.user + '%';
@@ -453,8 +453,11 @@ app.delete('/users/:id', auth.ensureAdminLevelOne, function (req, res) {
                     if (countForms > 0) {
                       res.status(403).send("Has associated Forms");
                     } else {
-                      user.destroy();  //destroy user
-                      res.sendStatus(200);
+                      // Mark record deleted, rather than destroying it.
+                      user.isDeleted = true;
+                      user.save().then(function() {
+                        res.sendStatus(200);
+                      });
                     }
                   });
                 }

--- a/migrations/20160504-140300-add_isDeleted.js
+++ b/migrations/20160504-140300-add_isDeleted.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: function (queryInterface, Sequelize, done) {
+    queryInterface.sequelize.query('ALTER TABLE users ADD "isDeleted" boolean DEFAULT false').then(function() {
+      queryInterface.sequelize.query('CREATE VIEW users_active AS SELECT * FROM users WHERE "isDeleted"=false').then(function() {
+        queryInterface.sequelize.query('ALTER TABLE groups ADD "isDeleted" boolean DEFAULT false').then(function() {
+          queryInterface.sequelize.query('CREATE VIEW groups_active AS SELECT * FROM groups WHERE "isDeleted"=false').then(function() {
+            done();
+          });
+        });
+      });
+    });
+  },
+
+  down: function (queryInterface, Sequelize, done) {
+    queryInterface.sequelize.query('ALTER TABLE users DROP "isDeleted"').then(function() {
+      queryInterface.sequelize.query('DROP VIEW users_active').then(function() {
+        queryInterface.sequelize.query('ALTER TABLE groups DROP "isDeleted"').then(function() {
+          queryInterface.sequelize.query('DROP VIEW groups_active').then(function() {
+                      done();
+          });
+        });
+      });
+    });
+  }
+};


### PR DESCRIPTION
Fixes https://github.com/igarape/copcast-admin/issues/207

I've added a new isDeleted column to the users and groups tables.  Now rather than ever deleting these rows from the database, we instead set isDeleted=true.  I have also created SQL VIEWS ```users_active``` and ```groups_active``` which are used by the sequelize models and SQL queries - this is much simpler than adding extra WHERE clauses to every SELECT statement and ```db.user.findAndCountAll```, ```db.user.findAll```, etc call.

Currently there is still no way to view the deleted users or groups from the admin console, but it since the data is still around it shouldn't be too hard to add logic to display this to certain types of admins (this would require updating SQL query strings and maybe creating a new sequelize model that uses ```users``` rather than ```users_active``` and ```groups``` rather than ```groups_active```).

Also I've created a db migration which I've tested on my own machine, but I'm not sure how to deploy and run this on our cloud servers - please advise here.

Thanks!