### PR TITLE
Make user search case insensitive

### DIFF
--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -229,15 +229,15 @@ app.get('/users-paginated', auth.ensureAdminLevelOne, function (req, res) {
       console.log(req.query.filter);
       where["$or"] = [{
         username: {
-          $like: '%' + req.query.filter + '%'
+          $iLike: '%' + req.query.filter + '%'
         }
       }, {
         name: {
-          $like: '%' + req.query.filter + '%'
+          $iLike: '%' + req.query.filter + '%'
         }
       }, {
         email: {
-          $like: '%' + req.query.filter + '%'
+          $iLike: '%' + req.query.filter + '%'
         }
       }];
     }


### PR DESCRIPTION
Make user search case insensitive by switching from $like to $iLike (as per sequelize docs: http://docs.sequelizejs.com/en/latest/docs/querying/#operators)

Fixes https://github.com/igarape/copcast-admin/issues/225