### PR TITLE
Add groupName to 'users:heartbeat' websocket data

### DIFF
--- a/lib/heartbeats/index.js
+++ b/lib/heartbeats/index.js
@@ -8,19 +8,51 @@ var express = require('express'),
   auth = require('./../auth'),
   config = require('./../config');
 
+function getGroupNameFromHeartbeat(req) {
+  var connectedSockets = app.get('sockets').connected;
+  var connectedSocketKeys = Object.keys(connectedSockets);
+  for (var i = 0; i < connectedSocketKeys.length; i++) {
+    var socket = connectedSockets[connectedSocketKeys[i]];
+    if(socket.copcast.group.id == req.user.groupId) {
+      // Found a connected socket for this groupId, return the groupName
+      return Promise.resolve(socket.copcast.group.name);
+    }
+  }
+  // Connected socket not found for this user, look up group record
+  return req.user.getGroup().then(function (group) {
+    return group.name;
+  });
+}
+
+function updateConnectedAdminSockets(req, location, battery) {
+  getGroupNameFromHeartbeat(req).then(function (groupName) {
+    var connectedSockets = app.get('sockets').connected;
+    var connectedSocketKeys = Object.keys(connectedSockets);
+    for (var i = 0; i < connectedSocketKeys.length; i++) {
+      var socket = connectedSockets[connectedSocketKeys[i]];
+      if (socket.copcast.clientType == 'admin' && (socket.copcast.group.id == req.user.groupId || socket.copcast.group.isAdmin)) {
+        var data =  {
+          id: req.user.id,
+          name: req.user.name,
+          username: req.user.username,
+          location: location,
+          battery: battery,
+          groupId: req.user.groupId,
+          groupName: groupName,
+          profilePicture: req.user.profilePicture
+        };
+        socket.emit('users:heartbeat', data);
+      }
+    }
+  });
+}
+
 app.post("/heartbeats", auth.ensureUser, signing.verify, function (req, res) {
 
   var location = req.body.location;
   var battery = req.body.battery;
 
-  var connectedSockets = Object.keys(app.get('sockets').connected);
-  for (var i = 0; i < connectedSockets.length; i++) {
-    var socket = app.get('sockets').connected[connectedSockets[i]];
-    if (socket.copcast.clientType == 'admin' && (socket.copcast.group.id == req.user.groupId || socket.copcast.group.isAdmin)) {
-      socket.emit('users:heartbeat', { id : req.user.id, name: req.user.name, username: req.user.username,
-        location: location, battery: battery, profilePicture: req.user.profilePicture});
-    }
-  }
+  updateConnectedAdminSockets(req, location, battery);
 
   req.user.lastLat = location.lat;
   req.user.lastLng = location.lng;


### PR DESCRIPTION
Add groupName to 'users:heartbeat' websocket data, for https://github.com/igarape/copcast-admin/issues/289

Unfortunately the socket.copcast.group on https://github.com/igarape/copcast-server/blob/webrecorder/lib/heartbeats/index.js#L20 will always be the admin's group, not necessarily the same group as the user who is posting the heartbeat.

This change finds the group name of the user posting the heartbeat by:
* First searching for that groupName in connected sockets (the Android user should have a socket open if they are sending heartbeats, assuming video is streaming correctly)
* 2nd hitting the database to find the group record if they for some reason don't have a websocket open.

This could be cleaned up in the future if we send heartbeats over the websocket, rather than http (all socket objects have a .group property set, while http ```req``` objects just have the .user set)