### PR TITLE
Implement validation for bulk insert of battery entities.

### DIFF
--- a/lib/batteries/index.js
+++ b/lib/batteries/index.js
@@ -16,24 +16,51 @@ function containsElement(array, el){
   }
   return found;
 }
+
 app.post('/batteries/:user', auth.ensureToken, signing.verify, function(req,res) {
 
-  if (!('bulk' in req.body)) {
+  if (!('bulk' in req.body) || !Array.isArray(req.body.bulk)) {
     console.log("Missing bulk data in batteries for user: "+req.params.user);
-    return res.sendStatus(500);
+    return res.sendStatus(400);
   }
-
   db.user.find({where: {username: req.params.user}}).then(function(user){
     if (user == null)
       return res.sendStatus(404);
 
-    var batteries = []
-    _.forEach(req.body.bulk, function (bat) {
-      bat.userId = user.id;
-      if (!containsElement(batteries, bat)) {
-        batteries.push(bat);
+    var batteries = [], row;
+    if ( !req.body.bulk.some(function (bat) {
+      row = {userId: user.id};
+
+      //Validate the battery object
+      if (!('batteryHealth' in bat) ||
+          !('batteryPercentage' in bat) ||
+          !('temperature' in bat) ||
+          !('status' in bat) ||
+          !('plugged' in bat) ||
+          !('date' in bat) ||
+          (typeof bat['batteryHealth'] != 'number') ||
+          (typeof bat['batteryPercentage'] != 'number') ||
+          (typeof bat['temperature'] != 'number') ||
+          (typeof bat['status'] != 'number') ||
+          (typeof bat['plugged'] != 'number') ||
+          (typeof bat['date'] != 'string')) {
+        return false;
       }
-    });
+
+      row.batteryHealth = bat.batteryHealth;
+      row.batteryPercentage = bat.batteryPercentage;
+      row.temperature = bat.temperature;
+      row.status = bat.status;
+      row.plugged = bat.plugged;
+      row.date = bat.date;
+
+      if (!containsElement(batteries, row)) {
+        batteries.push(row);
+      }
+      return true;
+    })) {
+      return res.sendStatus(400);
+    }
 
     db.battery.bulkCreate(batteries)
       .then(function() {

--- a/test/batteries/batteries.js
+++ b/test/batteries/batteries.js
@@ -1,0 +1,60 @@
+var request = require('supertest'),
+  should = require('should'),
+  app = require('express')(),
+  proxyquire = require('proxyquire'),
+  auth = require('./../mocks/auth'),
+  db = require('./../../lib/db'),
+  rest = proxyquire('./../../lib/batteries', {'./../auth': auth, './../db': db}),
+  bodyParser = require('body-parser'),
+  config = require('./../../lib/config'),
+  factory = require('./../setup');
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({extended: true}));
+app.use(rest);
+
+auth.scope = 'client'; //set mock user scope
+
+config.signatureVerification = false;
+
+describe('Bulk battery upload', function() {
+  beforeEach(function (done) {
+    db.sequelize.sync({force: true}).then(function (err) {
+      factory.create('testUser', function (err, u) {
+        if (err) {
+          console.log(err);
+          done();
+        } else {
+          auth.user = u;  //set mock user
+          done();
+        }
+      });
+    });
+  });
+
+  describe('',function(){
+    it('will upload one item', function (done) {
+      request(app).post('/batteries/testuser')
+        .send({"bulk": [{"batteryHealth":100, "batteryPercentage": 100.0, "temperature": 97, "status": 100, "plugged": 1, "date": "2016-08-19T23:11:15.123Z"}]})
+        .expect(201)
+        .end(function (err, res) { should.not.exist(err); done(); });
+    });
+  });
+
+  describe('',function(){
+    it('will upload one fake array like', function (done) {
+      request(app).post('/batteries/testuser')
+        .send({"bulk": {"length" : 10}})
+        .expect(400)
+        .end(function (err, res) { should.not.exist(err); done(); });
+    });
+  });
+
+  describe('',function(){
+    it('will upload one malicious json', function (done) {
+      request(app).post('/batteries/testuser')
+        .send({"bulk": [{"batteryHealth": {"$iLike": "%"}}]})
+        .expect(400)
+        .end(function (err, res) { should.not.exist(err); done(); });
+    });
+  });
+});


### PR DESCRIPTION
 Partially addresses CC-01-017. Note that instead of a 500 error,
 this has been modified to return a 400 request if the bulk field
 is missing from the body of the request.
- This also includes a couple of small tests for bulk battery upload