### PR TITLE
Add request validation to registrations endpoint

### DIFF
--- a/lib/db/registration_history.js
+++ b/lib/db/registration_history.js
@@ -27,7 +27,36 @@ module.exports = function(sequelize, DataTypes) {
     }
   }, {
     tableName: 'registrations',
-    timestamps : false
+    timestamps : false,
+    classMethods: {
+      parseRequest: function (data, row) {
+        if (!data || typeof data !== 'object') {
+          return null;
+        }
+
+        if (!('username' in data) ||
+            !('imei' in data) ||
+            !('simid' in data) ||
+            !('public_key' in data) ||
+            (typeof data['imei'] !== 'string') ||
+            (typeof data['username'] !== 'string') ||
+            (typeof data['simid'] !== 'string') ||
+            (typeof data['public_key'] !== 'string')) {
+          return null;
+        }
+
+        if (!row) {
+          row = {};
+        }
+
+        row.username = data.username;
+        row.imei = data.imei;
+        row.simid = data.simid;
+        row.public_key = data.public_key;
+
+        return row;
+      }
+    }
   });
 
   return Registration;

--- a/lib/db/user.js
+++ b/lib/db/user.js
@@ -153,6 +153,46 @@ module.exports = function(sequelize, DataTypes) {
         }
       }
 
+    },
+    classMethods: {
+      parseRequest: function (data, row) {
+        if (!data || typeof data !== 'object') {
+          return null;
+        }
+
+        if (!('username' in data) ||
+            !('email' in data) ||
+            !('name' in data) ||
+            !('role' in data) ||
+            !('groupId' in data) ||
+            ('language' in data && typeof data['language'] !== 'string') ||
+            ('isAdmin' in data && typeof data['isAdmin'] !== 'boolean') ||
+            (typeof data['groupId'] !== 'number') ||
+            (typeof data['username'] !== 'string') ||
+            (typeof data['email'] !== 'string') ||
+            (typeof data['name'] !== 'string') ||
+            (typeof data['role'] !== 'string')) {
+          return null;
+        }
+
+        if (!row) {
+          row = {};
+        }
+
+        row.username = data.username;
+        row.email = data.email;
+        row.name = data.name;
+        row.role = data.role;
+        row.groupId = data.groupId;
+        if (data.language) {
+          row.language = data.language;
+        }
+        if (data.isAdmin) {
+          row.isAdmin = data.isAdmin;
+        }
+
+        return row;
+      }
     }
   });
 

--- a/lib/registrations/index.js
+++ b/lib/registrations/index.js
@@ -12,28 +12,26 @@ var express = require('express'),
 app.post('/registration', function(req,res) {
   console.log(req.connection.remoteAddress);
 
-  if (req.body.imei == null || req.body.simid == null ) {
+  var request = db.registration.parseRequest(req.body),
+                password = req.body.password;
+  if (request == null || !password || typeof password !== 'string') {
     return res.sendStatus(400); //return bad request
   }
 
-  db.user.find({ where : { username : req.body.username}}).then(function(user) {
+  db.user.find({ where : { username : request.username}}).then(function(user) {
     if (!user) {
       return res.sendStatus(401);
     }
 
-    user.validatePassword(req.body.password, function(valid) {
+    user.validatePassword(password, function(valid) {
       if (!valid || !auth.hasLevel(user, 'admin_1')) {
         return res.sendStatus(401);
       }
 
-      db.registration.upsert({
-        imei: req.body.imei,
-        simid: req.body.simid,
-        public_key: req.body.public_key,
-        ipaddress: req.connection.remoteAddress,
-        username: req.body.username,
-        createdAt: Date.now()
-      }).then(function(out){
+      request.createdAt = Date.now();
+      request.ipaddress = req.connection.remoteAddress;
+
+      db.registration.upsert(request).then(function(out){
         return res.sendStatus(201);
       }).catch(function(err) {
         console.log(err);

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -209,18 +209,20 @@ app.get('/users-paginated', auth.ensureAdminLevelOne, function (req, res) {
 });
 
 app.post('/users', auth.ensureAdminLevelOne, function (req, res) {
-  var user = db.user.build({
-    username: req.body.username,
-    email: req.body.email,
-    name: req.body.name,
-    role: req.body.role,
-    groupId: req.body.groupId,
-    isAdmin: req.body.isAdmin,
-    language: req.body.language
-  });
+  var row = db.user.parseRequest(req.body),
+      password = req.body.password,
+      user = null;
 
+  if (!password || typeof password !== 'string') {
+    return res.sendStatus(400);
+  }
+
+  if (!row) {
+    return res.sendStatus(400);
+  }
+  user = db.user.build(row);
   if (req.user.canModifyThisUser(user)) {
-    user.hashPassword(req.body.password, function () {
+    user.hashPassword(password, function () {
       user.save().then(function () {
         res.sendStatus(202);
       }).catch(function (err) {
@@ -237,8 +239,6 @@ app.post('/users/:id', auth.ensureAdminLevelOne, function (req, res) {
   if (req.user.canModifyThisUser(req.body)) {
     db.group.findById(req.user.groupId).then(function (group) {
       db.user.findById(req.params.id).then(function (user) {
-        console.log("users_post" + user.id + " : " + user.name);
-
         if ((group != null && group.isAdmin !== true && group.id != user.groupId) ||
           (!req.user.canModifyThisUser(user))) {
           res.status(403).send("You do not have permission to modify this user");

--- a/test/registrations/registrations.js
+++ b/test/registrations/registrations.js
@@ -1,0 +1,111 @@
+var request = require('supertest'),
+  should = require('should'),
+  app = require('express')(),
+  proxyquire = require('proxyquire'),
+  auth = require('./../mocks/auth'),
+  db = require('./../../lib/db'),
+  rest = proxyquire('./../../lib/registrations', {'./../auth': auth, './../db': db}),
+  bodyParser = require('body-parser'),
+  config = require('./../../lib/config'),
+  factory = require('./../setup');
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({extended: true}));
+app.use(rest);
+
+auth.scope = 'client'; //set mock user scope
+
+describe('Registrations', function() {
+  beforeEach(function (done) {
+    config.signatureVerification = false;
+    db.sequelize.sync({force: true}).then(function (err) {
+      factory.create('testUser', function (err, u) {
+        if (err) {
+          console.log(err);
+          done();
+        } else {
+          auth.user = u;  //set mock user
+          done();
+        }
+      });
+    });
+  });
+
+  describe('Performs registration',function(){
+    it('sends valid registration request',function(done) {
+      request(app).post('/registration')
+        .send({username: 'testuser', password: 'test1234', imei: '1213233323', simid: '8998977', public_key: '8293893'})
+        .expect(201)
+        .end(function (err, res) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('sends valid registration request with bad username',function(done) {
+      request(app).post('/registration')
+        .send({username: 'foo', password: 'test1234', imei: '1213233323', simid: '8998977', public_key: '8293893'})
+        .expect(401)
+        .end(function (err, res) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('sends valid registration request with bad password',function(done) {
+      request(app).post('/registration')
+        .send({username: 'testuser', password: 'foo', imei: '1213233323', simid: '8998977', public_key: '8293893'})
+        .expect(401)
+        .end(function (err, res) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('will upload one malicious json in username', function (done) {
+      request(app).post('/registration')
+        .send({username: {"$iLike": "%"}, password: 'test1234', imei: '1213233323', simid: '8998977', public_key: '8293893'})
+        .expect(400)
+        .end(function (err, res) { should.not.exist(err); done(); });
+    });
+
+    it('will upload one malicious json in password',function(done) {
+      request(app).post('/registration')
+        .send({username: 'testuser', password: {"$iLike": "%"}, imei: '1213233323', simid: '8998977', public_key: '8293893'})
+        .expect(400)
+        .end(function (err, res) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('will upload one malicious json in imei',function(done) {
+      request(app).post('/registration')
+        .send({username: 'testuser', password: 'test1234', imei: {"$iLike": "%"}, simid: '8998977', public_key: '8293893'})
+        .expect(400)
+        .end(function (err, res) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('will upload one malicious json in simid',function(done) {
+      request(app).post('/registration')
+        .send({username: 'testuser', password: 'test1234', imei: '1213233323', simid: {"$iLike": "%"}, public_key: '8293893'})
+        .expect(400)
+        .end(function (err, res) {
+          should.not.exist(err);
+          done();
+        });
+    });
+
+    it('will upload one malicious json in public_key',function(done) {
+      request(app).post('/registration')
+        .send({username: 'testuser', password: 'test1234', imei: '1213233323', simid: '8998977', public_key: {"$iLike": "%"}})
+        .expect(400)
+        .end(function (err, res) {
+          should.not.exist(err);
+          done();
+        });
+    });
+  });
+});

--- a/test/users/users.js
+++ b/test/users/users.js
@@ -80,6 +80,7 @@ describe('Users Tests', function() {
     var group = null,
       newUser = {
         username: 'username',
+        password: 'mypassword',
         email: 'user@email.com',
         name: 'Name',
         role: 'admin_3',
@@ -104,17 +105,123 @@ describe('Users Tests', function() {
         .send(newUser)
         .expect(401)
         .end(function(err, res) {
+          should.not.exist(err);
           done();
         });
     });
 
 
     it('should create one user', function(done){
-
       request(app).post('/users')
         .send(newUser)
-        .expect(200)
+        .expect(202)
         .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should fail to create one user with bad username', function(done){
+      var brokenUser = JSON.parse(JSON.stringify(newUser));
+      brokenUser.username = {"$iLike": "%"};
+      request(app).post('/users')
+        .send(brokenUser)
+        .expect(400)
+        .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should fail to create one user with bad password', function(done){
+      var brokenUser = JSON.parse(JSON.stringify(newUser));
+      brokenUser.password = {"$iLike": "%"};
+      request(app).post('/users')
+        .send(brokenUser)
+        .expect(400)
+        .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should fail to create one user with bad email', function(done){
+      var brokenUser = JSON.parse(JSON.stringify(newUser));
+      brokenUser.email = {"$iLike": "%"};
+      request(app).post('/users')
+        .send(brokenUser)
+        .expect(400)
+        .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should fail to create one user with bad name', function(done){
+      var brokenUser = JSON.parse(JSON.stringify(newUser));
+      brokenUser.name = {"$iLike": "%"};
+      request(app).post('/users')
+        .send(brokenUser)
+        .expect(400)
+        .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should fail to create one user with bad role', function(done){
+      var brokenUser = JSON.parse(JSON.stringify(newUser));
+      brokenUser.role = {"$iLike": "%"};
+      request(app).post('/users')
+        .send(brokenUser)
+        .expect(400)
+        .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should fail to create one user with bad isAdmin', function(done){
+      var brokenUser = JSON.parse(JSON.stringify(newUser));
+      brokenUser.isAdmin = {"$iLike": "%"};
+      request(app).post('/users')
+        .send(brokenUser)
+        .expect(400)
+        .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should fail to create one user with bad language', function(done){
+      var brokenUser = JSON.parse(JSON.stringify(newUser));
+      brokenUser.language = {"$iLike": "%"};
+      request(app).post('/users')
+        .send(brokenUser)
+        .expect(400)
+        .end(function(err, res) {
+          should.not.exist(err);
           db.user.findOne({username: newUser.username}).then(function(user){
             should.exist(user);
             done();


### PR DESCRIPTION
Note that while working on this I noticed there are 2 duplicate registration entities defined in lib/db/registration.js and lib/db/registration_history.js. The second one overwrites the first one, so I recommend removing one of them as it may cause confusion in the future.