### PR TITLE
Modify ingestion to create intermediate tmp file prior to encryption

### DIFF
--- a/lib/db/user.js
+++ b/lib/db/user.js
@@ -163,7 +163,6 @@ module.exports = function(sequelize, DataTypes) {
         if (!('username' in data) ||
             !('email' in data) ||
             !('name' in data) ||
-            !('role' in data) ||
             !('groupId' in data) ||
             ('language' in data && typeof data['language'] !== 'string') ||
             ('isAdmin' in data && typeof data['isAdmin'] !== 'boolean') ||
@@ -171,7 +170,7 @@ module.exports = function(sequelize, DataTypes) {
             (typeof data['username'] !== 'string') ||
             (typeof data['email'] !== 'string') ||
             (typeof data['name'] !== 'string') ||
-            (typeof data['role'] !== 'string')) {
+            ('role' in data && typeof data['role'] !== 'string')) {
           return null;
         }
 

--- a/lib/videos/storage/file.js
+++ b/lib/videos/storage/file.js
@@ -198,15 +198,17 @@ exports.ingestVideo = function (rawVideoPath, user, dateRecorded, callback) {
 
     var video = db.video.build({id: uuid.v4(), date: dateRecorded, duration: duration});
     video.setUser(user, {save: false});
-    var enc_video_path = basePath + video.encVideoPath();
-    var enc_audio_path = basePath + video.encAudioPath();
+    var unenc_video_path = basePath + video.videoPath() + '.tmp',
+        unenc_audio_path = basePath + video.audioPath() + '.tmp',
+        enc_video_path = basePath + video.encVideoPath(),
+        enc_audio_path = basePath + video.encAudioPath();
 
     fs.mkdir(path.dirname(enc_video_path), 0777, true, function (err) {
       if (err)
         return callback(500, "mkdir error: "+err);
 
       var ffmpeg = new FFmpeg({source: rawVideoPath});
-      var vid_output_stream = fs.createWriteStream(enc_video_path);
+      var unencrypted_vid_output_stream = fs.createWriteStream(unenc_video_path);
 
       var outpipe = ffmpeg.on('error', function (err, stdout, stderr) {
         return callback(500, "ffmpeg error: "+err);
@@ -259,25 +261,48 @@ exports.ingestVideo = function (rawVideoPath, user, dateRecorded, callback) {
         }
       } // file ingestion
 
-      vid_output_stream.on('finish', function () {
+      unencrypted_vid_output_stream.on('finish', function () {
+        var unencrypted_video_stream = fs.createReadStream(unenc_video_path),
+            encrypted_video_stream = fs.createWriteStream(enc_video_path);
+        meter = new StreamMeter();
+        unencrypted_video_stream.pipe(meter).pipe(crypto.encryptor()).pipe(encrypted_video_stream);
 
-        console.log('finish video');
-        var enc_audio_path = basePath + video.encAudioPath();
-        var audio_ffmpeg = new FFmpeg({source: rawVideoPath});
-        var audio_output_stream = fs.createWriteStream(enc_audio_path);
-        audio_ffmpeg = audio_ffmpeg.withNoVideo().addOption(['-strict -2', '-c:a copy']);
+        unencrypted_video_stream.on('end', function() {
+          fs.unlink(unenc_video_path, function(err) {
+            if (err) {
+                console.error('Error removing unencrypted temporary video file: ' + unenc_video_path, err);
+            }
 
-        //even if audio is not correctly produced, register video in database
-        audio_ffmpeg.on('end', function () {
-          console.log('audio done.')
-          finalize_ingestion();
-        }).on('error', function (err) {
-          console.log(err);
-          finalize_ingestion();
+            console.log('finish video');
+            var enc_audio_path = basePath + video.encAudioPath();
+            var audio_ffmpeg = new FFmpeg({source: rawVideoPath});
+            var audio_output_stream = fs.createWriteStream(unenc_audio_path);
+            audio_ffmpeg = audio_ffmpeg.withNoVideo().addOption(['-strict -2', '-c:a copy']);
+
+            //even if audio is not correctly produced, register video in database
+            audio_ffmpeg.on('end', function () {
+              var unencrypted_audio_stream = fs.createReadStream(unenc_audio_path),
+                  encrypted_audio_stream = fs.createWriteStream(enc_audio_path);
+              unencrypted_audio_stream.pipe(crypto.encryptor()).pipe(encrypted_audio_stream);
+
+              unencrypted_audio_stream.on('end', function() {
+                fs.unlink(unenc_audio_path, function(err) {
+                  if (err) {
+                    console.error('Error removing unencrypted temporary audio file: ' + unenc_audio_path, err);
+                  }
+
+                  console.log('audio done.')
+                  finalize_ingestion();
+                });
+              });
+            }).on('error', function (err) {
+              console.log(err);
+              finalize_ingestion();
+            });
+
+            audio_ffmpeg.format('mp4').outputOptions('-movflags frag_keyframe+empty_moov').pipe().pipe(audio_output_stream);
+          });
         });
-
-        audio_ffmpeg.format('mp4').outputOptions('-movflags frag_keyframe+empty_moov').pipe().pipe(crypto.encryptor()).pipe(audio_output_stream);
-
       }).on('error', function (err) {
         return callback(500, "error finishing output stream: "+err);
       });
@@ -294,8 +319,7 @@ exports.ingestVideo = function (rawVideoPath, user, dateRecorded, callback) {
       //   outpipe = outpipe.addOption('-vf', 'movie=' + watermarkPath + ' [watermark]; [in] [watermark] overlay=(main_w-overlay_w):(main_h-overlay_h) [out]')
       // }
 
-      meter = new StreamMeter();
-      outpipe.format('mp4').addOption(['-c:v copy', '-strict -2']).outputOptions('-movflags frag_keyframe+empty_moov').pipe().pipe(meter).pipe(crypto.encryptor()).pipe(vid_output_stream);
+      outpipe.format('mp4').addOption(['-c:v copy', '-strict -2']).outputOptions('-movflags frag_keyframe+empty_moov').pipe().pipe(unencrypted_vid_output_stream);
     });
   });
 };

--- a/test/users/users.js
+++ b/test/users/users.js
@@ -83,8 +83,6 @@ describe('Users Tests', function() {
         password: 'mypassword',
         email: 'user@email.com',
         name: 'Name',
-        role: 'admin_3',
-        isAdmin: true,
         language: 'en'
       };
 
@@ -111,9 +109,25 @@ describe('Users Tests', function() {
     });
 
 
-    it('should create one user', function(done){
+    it('should create one user without role', function(done){
       request(app).post('/users')
         .send(newUser)
+        .expect(202)
+        .end(function(err, res) {
+          should.not.exist(err);
+          db.user.findOne({username: newUser.username}).then(function(user){
+            should.exist(user);
+            done();
+          })
+        });
+    });
+
+    it('should create one user with role', function(done){
+      var userWithRole = JSON.parse(JSON.stringify(newUser));
+      userWithRole.role = 'admin_3';
+      userWithRole.isAdmin = true;
+      request(app).post('/users')
+        .send(userWithRole)
         .expect(202)
         .end(function(err, res) {
           should.not.exist(err);


### PR DESCRIPTION
@brunosiqueira I think this addresses the issue as far as my understanding of it. The ffmpeg output goes to a temp file (for both audio and video). Then that file is encrypted in a separate step and the intermediate file is deleted.

Also this merge request fixes an issue with the createuser endpoint not working because role isn't specified